### PR TITLE
Add d3-module keyword.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "CAM02 color space.",
   "keywords": [
     "d3",
+    "d3-module",
     "color",
     "cam02",
     "CIECAM02",


### PR DESCRIPTION
This keyword helps people find D3 4.x plugins.